### PR TITLE
Update react-native-foreground-service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 3.0.2
+- Fix for [#43](https://github.com/voximplant/react-native-foreground-service/issues/43): application is crashed when running on iOS
+- Fix for [#36](https://github.com/voximplant/react-native-foreground-service/issues/36): application build error on android targeting api 31+
+
 ### 3.0.1
 - Fix: Reference error on action button click if there are no handlers for this event
 

--- a/README.md
+++ b/README.md
@@ -59,24 +59,20 @@ See [the Android official documentation](https://developer.android.com/guide/com
     ```
 5. Add VIForegroundService as a service to the application's `AndroidManifest.xml`:
     ```
-    <service android:name="com.voximplant.foregroundservice.VIForegroundService"> </service>
-    ```
-
-### For Android API >= 31
-1. Add VIForegroundService as a service to the application's `AndroidManifest.xml`:
-    ```
     <service android:name="com.voximplant.foregroundservice.VIForegroundService"
              android:exported="false"> </service>
     ```
-2. Add android:exported="true" to the application's `AndroidManifest.xml` activity section
+6. ### For targetSdkVersion Android API >= 31
+    Add android:exported="true" to the application's `AndroidManifest.xml` activity section
     ```
     <activity
-                android:name=".MainActivity"
-                android:label="@string/app_name"
-                android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-                android:windowSoftInputMode="adjustResize"
-                android:exported="true"> <====== This line
+        android:name=".MainActivity"
+        android:label="@string/app_name"
+        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+        android:windowSoftInputMode="adjustResize"
+        android:exported="true">        <===== Add this line
     ```
+
 ## Demo project
 Demo application: [react-native-foreground-service-demo](https://github.com/voximplant/react-native-foreground-service-demo)
   	

--- a/README.md
+++ b/README.md
@@ -61,7 +61,22 @@ See [the Android official documentation](https://developer.android.com/guide/com
     ```
     <service android:name="com.voximplant.foregroundservice.VIForegroundService"> </service>
     ```
-    
+
+### For Android API >= 31
+1. Add VIForegroundService as a service to the application's `AndroidManifest.xml`:
+    ```
+    <service android:name="com.voximplant.foregroundservice.VIForegroundService"
+             android:exported="false"> </service>
+    ```
+2. Add android:exported="true" to the application's `AndroidManifest.xml` activity section
+    ```
+    <activity
+                android:name=".MainActivity"
+                android:label="@string/app_name"
+                android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+                android:windowSoftInputMode="adjustResize"
+                android:exported="true"> <====== This line
+    ```
 ## Demo project
 Demo application: [react-native-foreground-service-demo](https://github.com/voximplant/react-native-foreground-service-demo)
   	

--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ See [the Android official documentation](https://developer.android.com/guide/com
              android:exported="false"> </service>
     ```
 6. For targetSdkVersion Android API >= 31
-   Add android:exported="true" to the application's `AndroidManifest.xml` activity section
+
+    Add android:exported="true" to the application's `AndroidManifest.xml` activity section
     ```
     <activity
         android:name=".MainActivity"

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ See [the Android official documentation](https://developer.android.com/guide/com
     <service android:name="com.voximplant.foregroundservice.VIForegroundService"
              android:exported="false"> </service>
     ```
-6. ### For targetSdkVersion Android API >= 31
-    Add android:exported="true" to the application's `AndroidManifest.xml` activity section
+6. For targetSdkVersion Android API >= 31
+   Add android:exported="true" to the application's `AndroidManifest.xml` activity section
     ```
     <activity
         android:name=".MainActivity"

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const channelConfig = {
     description: 'Channel description',
     enableVibration: false
 };
-VIForegroundService.createNotificationChannel(channelConfig);
+await VIForegroundService.getInstance().createNotificationChannel(channelConfig);
 ```
 
 ### Start foreground service
@@ -109,7 +109,7 @@ async startForegroundService() {
         button: 'Some text',
     };
     try {
-        await VIForegroundService.startService(notificationConfig);
+        await VIForegroundService.getInstance().startService(notificationConfig);
     } catch (e) {
         console.error(e);
     }
@@ -118,7 +118,7 @@ async startForegroundService() {
 
 ### Stop foreground service
 ```javascript
-VIForegroundService.stopService();
+await VIForegroundService.getInstance().stopService();
 ```
 
 ## Reference

--- a/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
+++ b/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
@@ -82,7 +82,8 @@ class NotificationHelper {
             return null;
         }
         Intent notificationIntent = new Intent(context, mainActivityClass);
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, notificationIntent,
+                (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) ? (PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT) : PendingIntent.FLAG_UPDATE_CURRENT);
 
         Notification.Builder notificationBuilder;
 
@@ -133,7 +134,8 @@ class NotificationHelper {
         if (notificationConfig.containsKey("button")) {
             Intent buttonIntent = new Intent();
             buttonIntent.setAction(FOREGROUND_SERVICE_BUTTON_PRESSED);
-            PendingIntent pendingButtonIntent = PendingIntent.getBroadcast(context, 0, buttonIntent, PendingIntent.FLAG_ONE_SHOT);
+            PendingIntent pendingButtonIntent = PendingIntent.getBroadcast(context, 0, buttonIntent,
+                    (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) ? (PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT) : PendingIntent.FLAG_UPDATE_CURRENT);
 
             notificationBuilder.addAction(0, notificationConfig.getString("button"), pendingButtonIntent);
         }

--- a/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
+++ b/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
@@ -82,7 +82,7 @@ class NotificationHelper {
             return null;
         }
         Intent notificationIntent = new Intent(context, mainActivityClass);
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
 
         Notification.Builder notificationBuilder;
 
@@ -133,7 +133,7 @@ class NotificationHelper {
         if (notificationConfig.containsKey("button")) {
             Intent buttonIntent = new Intent();
             buttonIntent.setAction(FOREGROUND_SERVICE_BUTTON_PRESSED);
-            PendingIntent pendingButtonIntent = PendingIntent.getBroadcast(context, 0, buttonIntent, PendingIntent.FLAG_ONE_SHOT);
+            PendingIntent pendingButtonIntent = PendingIntent.getBroadcast(context, 0, buttonIntent, 0);
 
             notificationBuilder.addAction(0, notificationConfig.getString("button"), pendingButtonIntent);
         }

--- a/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
+++ b/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
@@ -82,7 +82,7 @@ class NotificationHelper {
             return null;
         }
         Intent notificationIntent = new Intent(context, mainActivityClass);
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         Notification.Builder notificationBuilder;
 
@@ -133,7 +133,7 @@ class NotificationHelper {
         if (notificationConfig.containsKey("button")) {
             Intent buttonIntent = new Intent();
             buttonIntent.setAction(FOREGROUND_SERVICE_BUTTON_PRESSED);
-            PendingIntent pendingButtonIntent = PendingIntent.getBroadcast(context, 0, buttonIntent, 0);
+            PendingIntent pendingButtonIntent = PendingIntent.getBroadcast(context, 0, buttonIntent, PendingIntent.FLAG_ONE_SHOT);
 
             notificationBuilder.addAction(0, notificationConfig.getString("button"), pendingButtonIntent);
         }

--- a/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
+++ b/android/src/main/java/com/voximplant/foregroundservice/NotificationHelper.java
@@ -82,7 +82,7 @@ class NotificationHelper {
             return null;
         }
         Intent notificationIntent = new Intent(context, mainActivityClass);
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, notificationIntent, PendingIntent.FLAG_UPDATE_CURRENT);
 
         Notification.Builder notificationBuilder;
 
@@ -110,12 +110,10 @@ class NotificationHelper {
             case -2:
                 priority = Notification.PRIORITY_MIN;
                 break;
-            case 1:
-                priority = Notification.PRIORITY_HIGH;
-                break;
             case 2:
                 priority = Notification.PRIORITY_MAX;
                 break;
+            case 1:
             default:
                 priority = Notification.PRIORITY_HIGH;
                 break;
@@ -135,7 +133,7 @@ class NotificationHelper {
         if (notificationConfig.containsKey("button")) {
             Intent buttonIntent = new Intent();
             buttonIntent.setAction(FOREGROUND_SERVICE_BUTTON_PRESSED);
-            PendingIntent pendingButtonIntent = PendingIntent.getBroadcast(context, 0, buttonIntent, 0);
+            PendingIntent pendingButtonIntent = PendingIntent.getBroadcast(context, 0, buttonIntent, PendingIntent.FLAG_ONE_SHOT);
 
             notificationBuilder.addAction(0, notificationConfig.getString("button"), pendingButtonIntent);
         }

--- a/index.js
+++ b/index.js
@@ -4,10 +4,16 @@
 
 'use strict';
 
-import { NativeModules, NativeEventEmitter } from 'react-native';
+import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
+
+const isIOS = Platform.OS === 'ios';
+const isAndroid = Platform.OS === 'android';
 
 const ForegroundServiceModule = NativeModules.VIForegroundService;
-const EventEmitter = new NativeEventEmitter(ForegroundServiceModule);
+let EventEmitter;
+if (isAndroid) {
+    EventEmitter = new NativeEventEmitter(ForegroundServiceModule);
+}
 
 /**
  * @property {string} channelId - Notification channel id to display notification
@@ -52,7 +58,9 @@ class VIForegroundService {
      * @private
      */
     constructor() {
-        EventEmitter.addListener('VIForegroundServiceButtonPressed', this._VIForegroundServiceButtonPressed.bind(this));
+        if (isAndroid) {
+            EventEmitter.addListener('VIForegroundServiceButtonPressed', this._VIForegroundServiceButtonPressed.bind(this));
+        }
     }
 
     static getInstance() {
@@ -69,6 +77,10 @@ class VIForegroundService {
      * @return Promise
      */
     async createNotificationChannel(channelConfig) {
+        if (isIOS) {
+            console.warn("ForegroundService may be used only Android platfrom.")
+            return;
+        }
         return await ForegroundServiceModule.createNotificationChannel(channelConfig);
     }
 
@@ -78,6 +90,10 @@ class VIForegroundService {
      * @return Promise
      */
     async startService(notificationConfig) {
+        if (isIOS) {
+            console.warn("ForegroundService may be used only Android platfrom.")
+            return;
+        }
         return await ForegroundServiceModule.startService(notificationConfig);
     }
 
@@ -87,6 +103,10 @@ class VIForegroundService {
      * @return Promise
      */
     async stopService() {
+        if (isIOS) {
+            console.warn("ForegroundService may be used only Android platfrom.")
+            return;
+        }
         return await ForegroundServiceModule.stopService();
     }
 
@@ -98,6 +118,10 @@ class VIForegroundService {
      * @param handler - Function to invoke when the specified event is emitted
      */
     on(event, handler) {
+        if (isIOS) {
+            console.warn("ForegroundService may be used only Android platfrom.")
+            return;
+        }
         if (!handler || !(handler instanceof Function)) {
             console.warn(`ForegroundService: on: handler is not a Function`);
             return;
@@ -117,6 +141,10 @@ class VIForegroundService {
      * @param handler - Handler function.
      */
     off(event, handler) {
+        if (isIOS) {
+            console.warn("ForegroundService may be used only Android platfrom.")
+            return;
+        }
         if (!this._listeners.has(event)) {
           return;
         }

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ class VIForegroundService {
      */
     async createNotificationChannel(channelConfig) {
         if (isIOS) {
-            console.warn("ForegroundService may be used only Android platfrom.")
+            console.warn("ForegroundService should be used only on Android platfrom.")
             return;
         }
         return await ForegroundServiceModule.createNotificationChannel(channelConfig);
@@ -91,7 +91,7 @@ class VIForegroundService {
      */
     async startService(notificationConfig) {
         if (isIOS) {
-            console.warn("ForegroundService may be used only Android platfrom.")
+            console.warn("ForegroundService should be used only on Android platfrom.")
             return;
         }
         return await ForegroundServiceModule.startService(notificationConfig);
@@ -104,7 +104,7 @@ class VIForegroundService {
      */
     async stopService() {
         if (isIOS) {
-            console.warn("ForegroundService may be used only Android platfrom.")
+            console.warn("ForegroundService should be used only on Android platfrom.")
             return;
         }
         return await ForegroundServiceModule.stopService();
@@ -119,7 +119,7 @@ class VIForegroundService {
      */
     on(event, handler) {
         if (isIOS) {
-            console.warn("ForegroundService may be used only Android platfrom.")
+            console.warn("ForegroundService should be used only on Android platfrom.")
             return;
         }
         if (!handler || !(handler instanceof Function)) {
@@ -142,7 +142,7 @@ class VIForegroundService {
      */
     off(event, handler) {
         if (isIOS) {
-            console.warn("ForegroundService may be used only Android platfrom.")
+            console.warn("ForegroundService should be used only on Android platfrom.")
             return;
         }
         if (!this._listeners.has(event)) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voximplant/react-native-foreground-service",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "React native module to start foreground service on android",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
There is a VoxImplant foreground service crash on Android. And this happens to `Android 12(SDK 31)` 155 times(aprox. 90%) last 28 days. 

The[ last releases (v3.0.2)](https://github.com/voximplant/react-native-foreground-service/releases/tag/v3.0.2) fixed `SDK 31 is not supported` problem. 